### PR TITLE
Properly sized UnderTextbox in LightBattleUI

### DIFF
--- a/libraries/magical_glass/scripts/objects/LightBattle.lua
+++ b/libraries/magical_glass/scripts/objects/LightBattle.lua
@@ -328,7 +328,13 @@ function LightBattle:postInit(state, encounter)
     end
 end
 
+---@deprecated
 function LightBattle:getSoulPosition()
+    Kristal.Console:warn("Deprecated method LightBattle:getSoulPosition in use")
+    return self:getSoulLocation()
+end
+
+function LightBattle:getSoulLocation()
     if self.soul then
         return self.soul:getPosition()
     end
@@ -2429,7 +2435,7 @@ function LightBattle:onKeyPressed(key)
             -- "You dare bring light into my lair? You must die!" -Ganon 1993
             if key == "j" and Input.shift() then
                 if self.soul then
-                    Game:gameOver(self:getSoulPosition())
+                    Game:gameOver(self:getSoulLocation())
                 else
                     Game:gameOver()
                 end

--- a/libraries/magical_glass/scripts/objects/lightbattle/ui/LightBattleUI.lua
+++ b/libraries/magical_glass/scripts/objects/lightbattle/ui/LightBattleUI.lua
@@ -5,7 +5,7 @@ function LightBattleUI:init()
 
     self.current_encounter_text = Game.battle.encounter.text
 
-    self.encounter_text = UnderTextbox(14, 17, SCREEN_WIDTH - 30, SCREEN_HEIGHT - 53, "main_mono", nil, true)
+    self.encounter_text = UnderTextbox(14, 17, (SCREEN_WIDTH) - (105), SCREEN_HEIGHT - 53, "main_mono", nil, true)
     self.encounter_text.text.default_voice = "battle"
     self.encounter_text.text.line_offset = 5
     self.encounter_text:setText("")


### PR DESCRIPTION
Which issue does this pertain to? If it doesn't pertain to an issue, why was it submitted?

Crash on Ctrl+Shift+j, overflowing "absentmindedly" in test dummy fight

What does your pull request add? Be specific.
Please use an unordered list.

* LightBattle:getSoulLocation() for gameover
* Properly sized UnderTextbox in LightBattleUI